### PR TITLE
Don't remove chat hooks of other addons

### DIFF
--- a/LFT.lua
+++ b/LFT.lua
@@ -1592,7 +1592,12 @@ local hookChatFrame = function(frame)
     local original = frame.AddMessage
 
     if original then
+        local skiphook = nil
         frame.AddMessage = function(t, message, ...)
+            if skiphook then
+                return original(t, message, unpack(arg))
+            end
+
             LFT.hookExecutions = LFT.hookExecutions + 1
 
             if string.find(message, 'Players online:', 1, true) and
@@ -1620,8 +1625,6 @@ local hookChatFrame = function(frame)
             if not LFT.gotTimeFromServer then
                 if LFT.gotOnline and LFT.gotUptime then
                     LFT.gotTimeFromServer = true
-                    frame.AddMessage = original
-                    original = nil
                 end
             end
 


### PR DESCRIPTION
In the current state, the ":AddMessage" function gets saved on login,
and is then restored when the addon receives an answer from the server.

This has some side effects to all other addons that work with the chat:
As the original function is saved when the game loads, it is then restored
again, as it was when LFT hooked it. That means, that every addon that hooks
the ChatFrame.AddMessage before LFT receives an answer from the server,
get its hook removed by LFT.

1. AddMessage (orig) gets saved by LFT
2. LFT Hooks AddMessage (orig+LFT)
3. Other addon hooks AddMessage (orig+LFT+other)
4. LFT receives an answer from server and sets AddMessage to "orig".
=> Every hook applied between step 2 and 4 is removed.

For other addons that means they would have to:
1) Rename itself to something like "!!!AddonName" to make sure to load before LFT
2) Hardcode checks for LFT to make sure it finished before own hooks are added

With this change, the LFT addon does no longer overwrite AddMessage to outdated
states and therefore hooks from other addons no longer get deleted by LFT.