### PR TITLE
Add warning to lv 1-12 users, that the addon won't work until lv 13

### DIFF
--- a/LFT.lua
+++ b/LFT.lua
@@ -3786,6 +3786,14 @@ function LFT_Toggle()
         LFT.level = UnitLevel('player')
     end
 
+    -- Without this warning message, players that are lv 1-12
+    -- trying to use LFT end up thinking the addon is broken
+    if LFT.level >= 13 then
+        _G['LFTLowLevel']:Hide()
+    else
+        _G['LFTLowLevel']:Show()
+    end
+
     for dungeon, data in next, LFT.dungeons do
         if not LFT.dungeonsSpam[data.code] then
             LFT.dungeonsSpam[data.code] = { tank = 0, healer = 0, damage = 0 }

--- a/LFT.xml
+++ b/LFT.xml
@@ -1739,6 +1739,20 @@
                                 </Anchor>
                             </Anchors>
                         </FontString>
+
+                        <FontString name="LFTLowLevel" inherits="GameFontWhite"
+                                    text="You are not level 13 yet. Go level up first!">
+                            <Size>
+                                <AbsDimension x="300" y="326"/>
+                            </Size>
+                            <Anchors>
+                                <Anchor point="CENTER">
+                                    <Offset>
+                                        <AbsDimension x="-10" y="30"/>
+                                    </Offset>
+                                </Anchor>
+                            </Anchors>
+                        </FontString>
                     </Layer>
                 </Layers>
                 <Frames>


### PR DESCRIPTION
when i've been supporting users in discord #addons this has come up multiple times, that people think LFT is broken, but the issue is that they were under lv 13 and so the addon looked brokenly empty

I copied over a little text box and added a show condition to add a warning that no, LFT is installed correctly in working, they just need to level up first

![image](https://github.com/CosminPOP/LFT/assets/11151284/423d2959-5e9b-45ff-94e6-54e581cec6b4)

I'm really not sure what that text should say exactly. This is what I came up with and it's alright i guess